### PR TITLE
Add release workflow for versioned and latest pyz

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Build and Release pyz
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - id: get-version
+        run: |
+          VERSION=$(python - <<'PY'
+import tomllib, pathlib
+data = tomllib.loads(pathlib.Path('pyproject.toml').read_text())
+print(data['project']['version'])
+PY
+          )
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Build pyz
+        run: python -m zipapp -o "remove_desktop_ini-${{ steps.get-version.outputs.version }}.pyz"
+
+      - name: Copy latest alias
+        run: cp "remove_desktop_ini-${{ steps.get-version.outputs.version }}.pyz" remove_desktop_ini-latest.pyz
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: remove-desktop-ini-${{ steps.get-version.outputs.version }}
+          path: |
+            remove_desktop_ini-${{ steps.get-version.outputs.version }}.pyz
+            remove_desktop_ini-latest.pyz
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            remove_desktop_ini-${{ steps.get-version.outputs.version }}.pyz
+            remove_desktop_ini-latest.pyz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Takashi Sasaki
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -72,3 +72,12 @@ python remove_desktop_ini.pyz --help  # or simply "python remove_desktop_ini.pyz
 5.  **Quit:** Press `Q` to quit the application. A confirmation dialog will appear.
 
 6.  **Usage Guide:** Press `?` at any time to display a quick usage guide within the application.
+
+## Author
+
+Takashi Sasaki (<takashi316@gmail.com>)  
+https://x.com/TakashiSasaki
+
+## License
+
+MIT License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ requires-python = ">=3.11"
 dependencies = [
     "textual",
 ]
+authors = [{name = "Takashi Sasaki", email = "takashi316@gmail.com"}]
+license = {file = "LICENSE"}
+urls = {Homepage = "https://x.com/TakashiSasaki"}
 
 [project.scripts]
 remove-desktop-ini = "remove_desktop_ini.app:main"


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to package a versioned `.pyz` and a `latest` alias
- include author, license, and project URL metadata
- document author and license
- enable manual triggering of the release workflow

## Testing
- `pip install -e .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891e789e0f4832b9df8e826d7b0e7e0