### PR TITLE
Add workflow for merging remove-desktop-ini subtree

### DIFF
--- a/.github/workflows/merge-remove-desktop-ini.yml
+++ b/.github/workflows/merge-remove-desktop-ini.yml
@@ -1,0 +1,29 @@
+name: Merge remove-desktop-ini subtree
+
+on:
+  workflow_dispatch:
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v3
+        with:
+          ref: main
+          fetch-depth: 0
+      
+      - name: Configure git
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+
+      - name: Fetch subtree branch
+        run: git fetch origin remove-desktop-ini
+
+      - name: Merge subtree
+        run: |
+          git subtree merge --prefix=remove-desktop-ini origin/remove-desktop-ini -m "Merge remove-desktop-ini subtree"
+
+      - name: Push changes
+        run: git push origin HEAD:main


### PR DESCRIPTION
## Summary
- add manual GitHub Actions workflow to merge `remove-desktop-ini` branch back into `main` using `git subtree merge`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6892a8e412ec832b84efa2e50dd7927a