### PR TITLE
Add workflows for remove-desktop-ini subtree management

### DIFF
--- a/.github/workflows/split-remove-desktop-ini.yml
+++ b/.github/workflows/split-remove-desktop-ini.yml
@@ -1,11 +1,11 @@
 ---
-name: Merge remove-desktop-ini subtree
+name: Create remove-desktop-ini subtree branch
 
 'on':
   workflow_dispatch: {}
 
 jobs:
-  merge:
+  split:
     runs-on: ubuntu-latest
     steps:
       - name: Ensure main branch
@@ -23,12 +23,8 @@ jobs:
         run: |
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
-      - name: Fetch subtree branch
-        run: git fetch origin remove-desktop-ini
-      - name: Merge subtree
+      - name: Split subtree to branch
         run: |
-          git subtree merge \
-            --prefix=remove-desktop-ini origin/remove-desktop-ini \
-            -m "Merge remove-desktop-ini subtree"
-      - name: Push changes
-        run: git push origin HEAD:main
+          git subtree split --prefix=remove-desktop-ini \
+            --branch remove-desktop-ini
+          git push origin remove-desktop-ini

--- a/.github/workflows/update-remove-desktop-ini.yml
+++ b/.github/workflows/update-remove-desktop-ini.yml
@@ -1,11 +1,11 @@
 ---
-name: Merge remove-desktop-ini subtree
+name: Sync remove-desktop-ini branch from main
 
 'on':
   workflow_dispatch: {}
 
 jobs:
-  merge:
+  update:
     runs-on: ubuntu-latest
     steps:
       - name: Ensure main branch
@@ -23,12 +23,7 @@ jobs:
         run: |
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
-      - name: Fetch subtree branch
-        run: git fetch origin remove-desktop-ini
-      - name: Merge subtree
+      - name: Push subtree branch
         run: |
-          git subtree merge \
-            --prefix=remove-desktop-ini origin/remove-desktop-ini \
-            -m "Merge remove-desktop-ini subtree"
-      - name: Push changes
-        run: git push origin HEAD:main
+          git fetch origin remove-desktop-ini || true
+          git subtree push --prefix=remove-desktop-ini origin remove-desktop-ini


### PR DESCRIPTION
## Summary
- add workflow to create remove-desktop-ini branch from main using git subtree split
- add workflow to sync remove-desktop-ini directory updates to its branch
- enforce branch check when merging subtree back into main

## Testing
- `python -m yamllint .github/workflows/split-remove-desktop-ini.yml .github/workflows/update-remove-desktop-ini.yml .github/workflows/merge-remove-desktop-ini.yml && echo "yamllint passed"`

------
https://chatgpt.com/codex/tasks/task_e_6892d02b2e10832b80262746f6ea5356